### PR TITLE
Fix race condition in visitor counter

### DIFF
--- a/public/counter.php
+++ b/public/counter.php
@@ -8,11 +8,19 @@ $file = $db_dir . '/counter_data.json';
 $today = date('Y-m-d');
 $ip = $_SERVER['REMOTE_ADDR'];
 
+// Open the counter file with an exclusive lock for safe concurrent updates
+$fp = fopen($file, 'c+');
+if ($fp === false) {
+    http_response_code(500);
+    exit;
+}
+flock($fp, LOCK_EX);
+rewind($fp);
+
 // Load or initialize data
-if (file_exists($file)) {
-    $data = json_decode(file_get_contents($file), true);
-    if (!is_array($data)) $data = [];
-} else {
+$contents = stream_get_contents($fp);
+$data = json_decode($contents, true);
+if (!is_array($data)) {
     $data = [];
 }
 
@@ -27,8 +35,13 @@ foreach ($data as $stored_ip => $last_date) {
 $data[$ip] = $today;
 
 // Save updated data
-file_put_contents($file, json_encode($data));
+ftruncate($fp, 0);
+rewind($fp);
+fwrite($fp, json_encode($data));
+fflush($fp);
+flock($fp, LOCK_UN);
+fclose($fp);
 
 // Return DAU count
 header('Content-Type: application/json');
-echo json_encode(['dau' => count($data)]); 
+echo json_encode(['dau' => count($data)]);


### PR DESCRIPTION
## Summary
- ensure counter.php uses file locking when updating the DAU file

## Testing
- `php -l public/counter.php`

------
https://chatgpt.com/codex/tasks/task_e_6871f1860c6083218c5a8802b0b7bcac