### PR TITLE
Update counter with file lock

### DIFF
--- a/public/counter.php
+++ b/public/counter.php
@@ -26,8 +26,13 @@ foreach ($data as $stored_ip => $last_date) {
 // Add/update today's visit for this IP
 $data[$ip] = $today;
 
-// Save updated data
-file_put_contents($file, json_encode($data));
+// Save updated data with an exclusive lock
+$result = file_put_contents($file, json_encode($data), LOCK_EX);
+if ($result === false) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Failed to update counter']);
+    exit;
+}
 
 // Return DAU count
 header('Content-Type: application/json');


### PR DESCRIPTION
## Summary
- apply exclusive file lock when updating counter
- return HTTP 500 with error JSON if counter write fails

## Testing
- `php -l public/counter.php`

------
https://chatgpt.com/codex/tasks/task_e_6871f544e398832187e784d8f66931d5